### PR TITLE
feat: add task deadlines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Tasks are stored as markdown files under `~/.rem-cli/tasks/` with directory-base
 ```
 
 - Status is determined by which directory the file resides in (not by frontmatter)
-- Frontmatter contains: `id`, `name`, `created_at`, `updated_at` (no `status` field)
+- Frontmatter contains: `id`, `name`, `created_at`, `updated_at`, `deadline` (no `status` field)
 - Status changes move the file between directories via `fs::rename`
 
 ## Key Patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Tasks are stored as markdown files under `~/.rem-cli/tasks/` with directory-base
 ```
 
 - Status is determined by which directory the file resides in (not by frontmatter)
-- Frontmatter contains: `id`, `name`, `created_at`, `updated_at`, `deadline` (no `status` field)
+- Frontmatter contains: `id`, `name`, `created_at`, `updated_at`, `deadline` in `yyyy/MM/dd` format (no `status` field)
 - Status changes move the file between directories via `fs::rename`
 
 ## Key Patterns

--- a/docs/reviews/codereview_PR11_20260611.md
+++ b/docs/reviews/codereview_PR11_20260611.md
@@ -1,0 +1,16 @@
+# The result of review
+Add task deadlines and overdue highlighting
+
+## ❌CRITICAL
+None.
+
+## 🔴HIGH
+### Comment1: Existing task migration can corrupt the original file
+The deadline migration writes directly to the task path with `fs::write`. If the write is interrupted or fails after truncation, the original task and its markdown body can be lost. Write the migrated content to a temporary file and replace the original only after the complete write succeeds.
+
+## 🟡MEDIUM
+### Comment1: Legacy deadline values are not normalized
+The loader accepts `yyyy-MM-dd`, but it leaves the old value unchanged on disk. This means the repository can indefinitely contain both formats despite `yyyy/MM/dd` being the current frontmatter contract. Normalize legacy values during the existing migration path.
+
+## 🔵LOW
+None.

--- a/src/render.rs
+++ b/src/render.rs
@@ -35,7 +35,7 @@ fn wrap_task_name(name: &str, width: usize) -> Text<'static> {
 fn task_text(task: &Task, width: usize) -> Text<'static> {
     let deadline = Line::styled(
         format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(Color::Gray),
     );
     Text::from(
         wrap_task_name(task.name.as_str(), width)
@@ -250,14 +250,14 @@ mod tests {
     }
 
     #[test]
-    fn task_text_displays_deadline_below_name_in_dark_gray() {
+    fn task_text_displays_deadline_below_name_in_gray() {
         // GIVEN
         let task = Task::new("deadline task".to_string());
         let expected = Text::from(vec![
             Line::from("deadline task"),
             Line::styled(
                 format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(Color::Gray),
             ),
         ]);
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,5 @@
 use crate::app::{App, Mode};
-use crate::task::{Task, TaskStatus};
+use crate::task::{DEADLINE_DATE_FORMAT, Task, TaskStatus};
 use chrono::{Local, NaiveDate};
 use ratatui::{
     prelude::*,
@@ -48,7 +48,7 @@ fn task_text(task: &Task, width: usize, today: NaiveDate, is_selected: bool) -> 
         Color::DarkGray
     };
     let deadline = Line::styled(
-        format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+        format!("Deadline: {}", task.deadline.format(DEADLINE_DATE_FORMAT)),
         Style::default().fg(deadline_color),
     );
     Text::from(
@@ -279,7 +279,7 @@ mod tests {
         let expected = Text::from(vec![
             Line::from("deadline task"),
             Line::styled(
-                format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+                format!("Deadline: {}", task.deadline.format(DEADLINE_DATE_FORMAT)),
                 Style::default().fg(Color::DarkGray),
             ),
         ]);
@@ -299,7 +299,7 @@ mod tests {
         let expected = Text::from(vec![
             Line::from("selected task"),
             Line::styled(
-                format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+                format!("Deadline: {}", task.deadline.format(DEADLINE_DATE_FORMAT)),
                 Style::default().fg(Color::Gray),
             ),
         ]);
@@ -320,7 +320,7 @@ mod tests {
         let expected = Text::from(vec![
             Line::styled("overdue task", Style::default().fg(Color::Yellow)),
             Line::styled(
-                format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+                format!("Deadline: {}", task.deadline.format(DEADLINE_DATE_FORMAT)),
                 Style::default().fg(OVERDUE_DEADLINE_COLOR),
             ),
         ]);

--- a/src/render.rs
+++ b/src/render.rs
@@ -37,9 +37,11 @@ fn wrap_task_name(name: &str, width: usize) -> Text<'static> {
 /// Builds the task text with its deadline below the wrapped name.
 fn task_text(task: &Task, width: usize, today: NaiveDate, is_selected: bool) -> Text<'static> {
     let is_overdue = task.deadline < today;
-    let name_style = is_overdue
-        .then_some(Style::default().fg(Color::Yellow))
-        .unwrap_or_default();
+    let name_style = if is_overdue {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
     let deadline_color = if is_overdue {
         OVERDUE_DEADLINE_COLOR
     } else if is_selected {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,5 @@
 use crate::app::{App, Mode};
-use crate::task::TaskStatus;
+use crate::task::{Task, TaskStatus};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
@@ -29,6 +29,21 @@ fn wrap_task_name(name: &str, width: usize) -> Text<'static> {
         lines.push(Line::from(current_line));
     }
     Text::from(lines)
+}
+
+/// Builds the task text with its deadline below the wrapped name.
+fn task_text(task: &Task, width: usize) -> Text<'static> {
+    let deadline = Line::styled(
+        format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+        Style::default().fg(Color::DarkGray),
+    );
+    Text::from(
+        wrap_task_name(task.name.as_str(), width)
+            .lines
+            .into_iter()
+            .chain([deadline])
+            .collect::<Vec<_>>(),
+    )
 }
 
 fn status_title_style(status: TaskStatus) -> Style {
@@ -81,10 +96,7 @@ pub fn render(frame: &mut Frame, app: &App) {
                 if app.selected_index == Some(global_idx) {
                     selected_in_group = Some(group_idx);
                 }
-                ListItem::new(wrap_task_name(
-                    t.name.as_str(),
-                    area.width.saturating_sub(2) as usize,
-                ))
+                ListItem::new(task_text(t, area.width.saturating_sub(2) as usize))
             })
             .collect();
         let border_style = if selected_in_group.is_some() {
@@ -232,6 +244,25 @@ mod tests {
 
         // WHEN
         let actual = wrap_task_name(task_name, width);
+
+        // THEN
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn task_text_displays_deadline_below_name_in_dark_gray() {
+        // GIVEN
+        let task = Task::new("deadline task".to_string());
+        let expected = Text::from(vec![
+            Line::from("deadline task"),
+            Line::styled(
+                format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]);
+
+        // WHEN
+        let actual = task_text(&task, 20);
 
         // THEN
         assert_eq!(actual, expected);

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,6 @@
 use crate::app::{App, Mode};
 use crate::task::{Task, TaskStatus};
+use chrono::{Local, NaiveDate};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
@@ -32,15 +33,25 @@ fn wrap_task_name(name: &str, width: usize) -> Text<'static> {
 }
 
 /// Builds the task text with its deadline below the wrapped name.
-fn task_text(task: &Task, width: usize) -> Text<'static> {
+fn task_text(task: &Task, width: usize, today: NaiveDate) -> Text<'static> {
+    let is_overdue = task.deadline < today;
+    let name_style = is_overdue
+        .then_some(Style::default().fg(Color::Yellow))
+        .unwrap_or_default();
+    let deadline_color = if is_overdue {
+        Color::LightYellow
+    } else {
+        Color::Gray
+    };
     let deadline = Line::styled(
         format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
-        Style::default().fg(Color::Gray),
+        Style::default().fg(deadline_color),
     );
     Text::from(
         wrap_task_name(task.name.as_str(), width)
             .lines
             .into_iter()
+            .map(|line| line.patch_style(name_style))
             .chain([deadline])
             .collect::<Vec<_>>(),
     )
@@ -83,6 +94,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     };
     let constraints = vec![Constraint::Ratio(1, statuses.len() as u32); statuses.len()];
     let columns = Layout::horizontal(constraints).split(outer[0]);
+    let today = Local::now().date_naive();
 
     for (column, ((status, title), area)) in statuses.iter().zip(columns.iter()).enumerate() {
         let mut selected_in_group: Option<usize> = None;
@@ -96,7 +108,7 @@ pub fn render(frame: &mut Frame, app: &App) {
                 if app.selected_index == Some(global_idx) {
                     selected_in_group = Some(group_idx);
                 }
-                ListItem::new(task_text(t, area.width.saturating_sub(2) as usize))
+                ListItem::new(task_text(t, area.width.saturating_sub(2) as usize, today))
             })
             .collect();
         let border_style = if selected_in_group.is_some() {
@@ -253,6 +265,7 @@ mod tests {
     fn task_text_displays_deadline_below_name_in_gray() {
         // GIVEN
         let task = Task::new("deadline task".to_string());
+        let today = task.deadline;
         let expected = Text::from(vec![
             Line::from("deadline task"),
             Line::styled(
@@ -262,7 +275,28 @@ mod tests {
         ]);
 
         // WHEN
-        let actual = task_text(&task, 20);
+        let actual = task_text(&task, 20, today);
+
+        // THEN
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn task_text_displays_overdue_task_in_yellow() {
+        // GIVEN
+        let mut task = Task::new("overdue task".to_string());
+        let today = task.deadline;
+        task.deadline = today.pred_opt().unwrap();
+        let expected = Text::from(vec![
+            Line::styled("overdue task", Style::default().fg(Color::Yellow)),
+            Line::styled(
+                format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+                Style::default().fg(Color::LightYellow),
+            ),
+        ]);
+
+        // WHEN
+        let actual = task_text(&task, 20, today);
 
         // THEN
         assert_eq!(actual, expected);

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,6 +6,8 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
 };
 
+const OVERDUE_DEADLINE_COLOR: Color = Color::Rgb(190, 180, 120);
+
 /// Wraps a task name to the available panel width.
 fn wrap_task_name(name: &str, width: usize) -> Text<'static> {
     if width == 0 || Line::from(name).width() <= width {
@@ -39,7 +41,7 @@ fn task_text(task: &Task, width: usize, today: NaiveDate, is_selected: bool) -> 
         .then_some(Style::default().fg(Color::Yellow))
         .unwrap_or_default();
     let deadline_color = if is_overdue {
-        Color::LightYellow
+        OVERDUE_DEADLINE_COLOR
     } else if is_selected {
         Color::Gray
     } else {
@@ -319,7 +321,7 @@ mod tests {
             Line::styled("overdue task", Style::default().fg(Color::Yellow)),
             Line::styled(
                 format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
-                Style::default().fg(Color::LightYellow),
+                Style::default().fg(OVERDUE_DEADLINE_COLOR),
             ),
         ]);
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -33,15 +33,17 @@ fn wrap_task_name(name: &str, width: usize) -> Text<'static> {
 }
 
 /// Builds the task text with its deadline below the wrapped name.
-fn task_text(task: &Task, width: usize, today: NaiveDate) -> Text<'static> {
+fn task_text(task: &Task, width: usize, today: NaiveDate, is_selected: bool) -> Text<'static> {
     let is_overdue = task.deadline < today;
     let name_style = is_overdue
         .then_some(Style::default().fg(Color::Yellow))
         .unwrap_or_default();
     let deadline_color = if is_overdue {
         Color::LightYellow
-    } else {
+    } else if is_selected {
         Color::Gray
+    } else {
+        Color::DarkGray
     };
     let deadline = Line::styled(
         format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
@@ -105,10 +107,16 @@ pub fn render(frame: &mut Frame, app: &App) {
             .filter(|(_, t)| t.status == *status)
             .enumerate()
             .map(|(group_idx, (global_idx, t))| {
-                if app.selected_index == Some(global_idx) {
+                let is_selected = app.selected_index == Some(global_idx);
+                if is_selected {
                     selected_in_group = Some(group_idx);
                 }
-                ListItem::new(task_text(t, area.width.saturating_sub(2) as usize, today))
+                ListItem::new(task_text(
+                    t,
+                    area.width.saturating_sub(2) as usize,
+                    today,
+                    is_selected,
+                ))
             })
             .collect();
         let border_style = if selected_in_group.is_some() {
@@ -262,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn task_text_displays_deadline_below_name_in_gray() {
+    fn task_text_displays_unselected_deadline_in_dark_gray() {
         // GIVEN
         let task = Task::new("deadline task".to_string());
         let today = task.deadline;
@@ -270,12 +278,32 @@ mod tests {
             Line::from("deadline task"),
             Line::styled(
                 format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]);
+
+        // WHEN
+        let actual = task_text(&task, 20, today, false);
+
+        // THEN
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn task_text_displays_selected_deadline_in_gray() {
+        // GIVEN
+        let task = Task::new("selected task".to_string());
+        let today = task.deadline;
+        let expected = Text::from(vec![
+            Line::from("selected task"),
+            Line::styled(
+                format!("Deadline: {}", task.deadline.format("%Y-%m-%d")),
                 Style::default().fg(Color::Gray),
             ),
         ]);
 
         // WHEN
-        let actual = task_text(&task, 20, today);
+        let actual = task_text(&task, 20, today, true);
 
         // THEN
         assert_eq!(actual, expected);
@@ -296,7 +324,7 @@ mod tests {
         ]);
 
         // WHEN
-        let actual = task_text(&task, 20, today);
+        let actual = task_text(&task, 20, today, false);
 
         // THEN
         assert_eq!(actual, expected);

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Days, Local, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io;
@@ -35,6 +35,7 @@ struct TaskFrontmatter {
     name: String,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
+    deadline: Option<NaiveDate>,
 }
 
 /// A TODO task with metadata and lifecycle status.
@@ -45,10 +46,18 @@ pub struct Task {
     pub status: TaskStatus,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub deadline: NaiveDate,
     base_dir: PathBuf,
 }
 
 impl Task {
+    fn tomorrow_deadline() -> NaiveDate {
+        Local::now()
+            .date_naive()
+            .checked_add_days(Days::new(1))
+            .expect("tomorrow should be a valid date")
+    }
+
     /// Creates a new task with the given name and TODO status.
     pub fn new(name: String) -> Self {
         Self::new_in(name, Self::default_base_dir())
@@ -63,6 +72,7 @@ impl Task {
             status: TaskStatus::Todo,
             created_at: now,
             updated_at: now,
+            deadline: Self::tomorrow_deadline(),
             base_dir,
         }
     }
@@ -89,6 +99,7 @@ impl Task {
             name: self.name.clone(),
             created_at: self.created_at,
             updated_at: self.updated_at,
+            deadline: Some(self.deadline),
         }
     }
 
@@ -111,18 +122,27 @@ impl Task {
             .unwrap_or("");
         let fm: TaskFrontmatter = serde_yaml::from_str(yaml)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        Ok(Self {
+        let deadline = fm.deadline.unwrap_or_else(Self::tomorrow_deadline);
+        let task = Self {
             id: fm.id,
             name: fm.name,
             status,
             created_at: fm.created_at,
             updated_at: fm.updated_at,
+            deadline,
             base_dir: path
                 .parent()
                 .and_then(Path::parent)
                 .map(Path::to_path_buf)
                 .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid task path"))?,
-        })
+        };
+        if fm.deadline.is_none() {
+            fs::write(
+                path,
+                task.content_with_frontmatter(&content, task.frontmatter())?,
+            )?;
+        }
+        Ok(task)
     }
 
     /// Reloads this task's metadata from its markdown file on disk.
@@ -241,6 +261,15 @@ impl Task {
             updated_at,
             ..self.frontmatter()
         };
+        self.content_with_frontmatter(existing, frontmatter)
+    }
+
+    /// Builds file content with the provided frontmatter while preserving the markdown body.
+    fn content_with_frontmatter(
+        &self,
+        existing: &str,
+        frontmatter: TaskFrontmatter,
+    ) -> io::Result<String> {
         let yaml = serde_yaml::to_string(&frontmatter).map_err(io::Error::other)?;
         let body = existing
             .strip_prefix("---\n")
@@ -307,7 +336,20 @@ mod tests {
         // THEN: it contains id, name, timestamps but not status
         assert_eq!(fm.id, task.id);
         assert_eq!(fm.name, "frontmatter test");
+        assert_eq!(fm.deadline, Some(task.deadline));
         assert!(!yaml.contains("status"));
+    }
+
+    #[test]
+    fn new_task_has_tomorrow_as_deadline() {
+        // GIVEN
+        let expected = Task::tomorrow_deadline();
+
+        // WHEN
+        let task = Task::new("deadline test".to_string());
+
+        // THEN
+        assert_eq!(task.deadline, expected);
     }
 
     #[test]
@@ -378,6 +420,64 @@ mod tests {
         assert_eq!(loaded.id, task.id);
         assert_eq!(loaded.name, "roundtrip test");
         assert_eq!(loaded.status, TaskStatus::Todo);
+        assert_eq!(loaded.deadline, task.deadline);
+        let content = fs::read_to_string(task.file_path()).unwrap();
+        assert!(content.contains(&format!("deadline: {}", task.deadline)));
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn load_adds_missing_deadline_without_changing_existing_content() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let task = Task::new_in("legacy task".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        let path = task.file_path();
+        let content = fs::read_to_string(&path).unwrap();
+        let legacy_content = format!(
+            "{}## Notes\n\nlegacy body\n",
+            content
+                .lines()
+                .filter(|line| !line.starts_with("deadline:"))
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n"
+        );
+        fs::write(&path, &legacy_content).unwrap();
+        let expected_deadline = Task::tomorrow_deadline();
+
+        // WHEN
+        let loaded = Task::load(&path, TaskStatus::Todo).unwrap();
+
+        // THEN
+        let migrated_content = fs::read_to_string(&path).unwrap();
+        assert_eq!(loaded.deadline, expected_deadline);
+        assert_eq!(loaded.created_at, task.created_at);
+        assert_eq!(loaded.updated_at, task.updated_at);
+        assert!(migrated_content.contains(&format!("deadline: {expected_deadline}")));
+        assert!(migrated_content.ends_with("## Notes\n\nlegacy body\n"));
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn load_returns_error_for_invalid_deadline() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let task = Task::new_in("invalid deadline".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        let path = task.file_path();
+        let content = fs::read_to_string(&path)
+            .unwrap()
+            .replace(&task.deadline.to_string(), "2026-02-30");
+        fs::write(&path, content).unwrap();
+
+        // WHEN
+        let result = Task::load(&path, TaskStatus::Todo);
+
+        // THEN
+        assert!(result.is_err());
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }
@@ -406,6 +506,7 @@ mod tests {
         assert!(task.updated_at > before_update);
         let content = fs::read_to_string(task.file_path()).unwrap();
         assert!(content.contains(body));
+        assert!(content.contains(&format!("deadline: {}", task.deadline)));
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Days, Local, NaiveDate, Utc};
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -7,34 +7,6 @@ use uuid::Uuid;
 
 pub const DEADLINE_DATE_FORMAT: &str = "%Y/%m/%d";
 const LEGACY_DEADLINE_DATE_FORMAT: &str = "%Y-%m-%d";
-
-mod optional_deadline_format {
-    use super::*;
-
-    pub fn serialize<S>(deadline: &Option<NaiveDate>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        deadline
-            .map(|date| date.format(DEADLINE_DATE_FORMAT).to_string())
-            .serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<NaiveDate>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = Option::<String>::deserialize(deserializer)?;
-        value
-            .map(|date| {
-                [DEADLINE_DATE_FORMAT, LEGACY_DEADLINE_DATE_FORMAT]
-                    .into_iter()
-                    .find_map(|format| NaiveDate::parse_from_str(&date, format).ok())
-                    .ok_or_else(|| D::Error::custom(format!("invalid deadline: {date}")))
-            })
-            .transpose()
-    }
-}
 
 /// Represents the lifecycle status of a task.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -66,8 +38,8 @@ struct TaskFrontmatter {
     name: String,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
-    #[serde(default, with = "optional_deadline_format")]
-    deadline: Option<NaiveDate>,
+    #[serde(default)]
+    deadline: Option<String>,
 }
 
 /// A TODO task with metadata and lifecycle status.
@@ -88,6 +60,15 @@ impl Task {
             .date_naive()
             .checked_add_days(Days::new(1))
             .expect("tomorrow should be a valid date")
+    }
+
+    fn parse_deadline(value: &str) -> io::Result<(NaiveDate, bool)> {
+        if let Ok(deadline) = NaiveDate::parse_from_str(value, DEADLINE_DATE_FORMAT) {
+            return Ok((deadline, false));
+        }
+        NaiveDate::parse_from_str(value, LEGACY_DEADLINE_DATE_FORMAT)
+            .map(|deadline| (deadline, true))
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
     }
 
     /// Creates a new task with the given name and TODO status.
@@ -131,7 +112,7 @@ impl Task {
             name: self.name.clone(),
             created_at: self.created_at,
             updated_at: self.updated_at,
-            deadline: Some(self.deadline),
+            deadline: Some(self.deadline.format(DEADLINE_DATE_FORMAT).to_string()),
         }
     }
 
@@ -154,7 +135,13 @@ impl Task {
             .unwrap_or("");
         let fm: TaskFrontmatter = serde_yaml::from_str(yaml)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        let deadline = fm.deadline.unwrap_or_else(Self::tomorrow_deadline);
+        let parsed_deadline = fm
+            .deadline
+            .as_deref()
+            .map(Self::parse_deadline)
+            .transpose()?;
+        let (deadline, needs_migration) =
+            parsed_deadline.unwrap_or_else(|| (Self::tomorrow_deadline(), true));
         let task = Self {
             id: fm.id,
             name: fm.name,
@@ -168,11 +155,9 @@ impl Task {
                 .map(Path::to_path_buf)
                 .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid task path"))?,
         };
-        if fm.deadline.is_none() {
-            fs::write(
-                path,
-                task.content_with_frontmatter(&content, task.frontmatter())?,
-            )?;
+        if needs_migration {
+            let migrated = task.content_with_frontmatter(&content, task.frontmatter())?;
+            Self::replace_file_content(path, &migrated, "md.migrate")?;
         }
         Ok(task)
     }
@@ -254,18 +239,7 @@ impl Task {
         let existing = fs::read_to_string(&old_path)?;
         let content = self.content_with_updated_frontmatter(&existing, updated_at)?;
         fs::create_dir_all(new_path.parent().unwrap())?;
-        let update_path = old_path.with_extension("md.update");
-        fs::write(&update_path, content)?;
-        if let Err(error) = fs::rename(&update_path, &old_path) {
-            let cleanup_result = fs::remove_file(&update_path);
-            return match cleanup_result {
-                Ok(()) => Err(error),
-                Err(cleanup_error) => Err(io::Error::new(
-                    error.kind(),
-                    format!("{error}; failed to remove temporary file: {cleanup_error}"),
-                )),
-            };
-        }
+        Self::replace_file_content(&old_path, &content, "md.update")?;
         if let Err(move_error) = fs::rename(&old_path, &new_path) {
             let rollback_path = old_path.with_extension("md.rollback");
             let rollback_result = fs::write(&rollback_path, existing)
@@ -308,6 +282,27 @@ impl Task {
             .and_then(|s| s.find("\n---\n").map(|pos| &s[pos + 5..]))
             .unwrap_or("");
         Ok(format!("---\n{}---\n{}", yaml, body))
+    }
+
+    /// Replaces a task file through a temporary file to avoid partial writes.
+    fn replace_file_content(
+        path: &Path,
+        content: &str,
+        temporary_extension: &str,
+    ) -> io::Result<()> {
+        let temporary_path = path.with_extension(temporary_extension);
+        fs::write(&temporary_path, content)?;
+        if let Err(error) = fs::rename(&temporary_path, path) {
+            let cleanup_result = fs::remove_file(&temporary_path);
+            return match cleanup_result {
+                Ok(()) => Err(error),
+                Err(cleanup_error) => Err(io::Error::new(
+                    error.kind(),
+                    format!("{error}; failed to remove temporary file: {cleanup_error}"),
+                )),
+            };
+        }
+        Ok(())
     }
 
     /// Sorts tasks by status group and by `created_at` within each group.
@@ -368,7 +363,10 @@ mod tests {
         // THEN: it contains id, name, timestamps but not status
         assert_eq!(fm.id, task.id);
         assert_eq!(fm.name, "frontmatter test");
-        assert_eq!(fm.deadline, Some(task.deadline));
+        assert_eq!(
+            fm.deadline,
+            Some(task.deadline.format(DEADLINE_DATE_FORMAT).to_string())
+        );
         assert!(!yaml.contains("status"));
     }
 
@@ -483,6 +481,15 @@ mod tests {
 
         // THEN
         assert_eq!(loaded.deadline, task.deadline);
+        let migrated_content = fs::read_to_string(&path).unwrap();
+        assert!(migrated_content.contains(&format!(
+            "deadline: {}",
+            task.deadline.format(DEADLINE_DATE_FORMAT)
+        )));
+        assert!(!migrated_content.contains(&format!(
+            "deadline: {}",
+            task.deadline.format(LEGACY_DEADLINE_DATE_FORMAT)
+        )));
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }
@@ -520,6 +527,33 @@ mod tests {
             expected_deadline.format(DEADLINE_DATE_FORMAT)
         )));
         assert!(migrated_content.ends_with("## Notes\n\nlegacy body\n"));
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn failed_deadline_migration_preserves_original_content() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let task = Task::new_in("failed migration".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        let path = task.file_path();
+        let original_content = fs::read_to_string(&path)
+            .unwrap()
+            .lines()
+            .filter(|line| !line.starts_with("deadline:"))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        fs::write(&path, &original_content).unwrap();
+        fs::create_dir(path.with_extension("md.migrate")).unwrap();
+
+        // WHEN
+        let result = Task::load(&path, TaskStatus::Todo);
+
+        // THEN
+        assert!(result.is_err());
+        assert_eq!(fs::read_to_string(&path).unwrap(), original_content);
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,9 +1,40 @@
 use chrono::{DateTime, Days, Local, NaiveDate, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
+
+pub const DEADLINE_DATE_FORMAT: &str = "%Y/%m/%d";
+const LEGACY_DEADLINE_DATE_FORMAT: &str = "%Y-%m-%d";
+
+mod optional_deadline_format {
+    use super::*;
+
+    pub fn serialize<S>(deadline: &Option<NaiveDate>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        deadline
+            .map(|date| date.format(DEADLINE_DATE_FORMAT).to_string())
+            .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<NaiveDate>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Option::<String>::deserialize(deserializer)?;
+        value
+            .map(|date| {
+                [DEADLINE_DATE_FORMAT, LEGACY_DEADLINE_DATE_FORMAT]
+                    .into_iter()
+                    .find_map(|format| NaiveDate::parse_from_str(&date, format).ok())
+                    .ok_or_else(|| D::Error::custom(format!("invalid deadline: {date}")))
+            })
+            .transpose()
+    }
+}
 
 /// Represents the lifecycle status of a task.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -35,6 +66,7 @@ struct TaskFrontmatter {
     name: String,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
+    #[serde(default, with = "optional_deadline_format")]
     deadline: Option<NaiveDate>,
 }
 
@@ -422,7 +454,35 @@ mod tests {
         assert_eq!(loaded.status, TaskStatus::Todo);
         assert_eq!(loaded.deadline, task.deadline);
         let content = fs::read_to_string(task.file_path()).unwrap();
-        assert!(content.contains(&format!("deadline: {}", task.deadline)));
+        assert!(content.contains(&format!(
+            "deadline: {}",
+            task.deadline.format(DEADLINE_DATE_FORMAT)
+        )));
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn load_accepts_legacy_deadline_format() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let task = Task::new_in("legacy deadline format".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        let path = task.file_path();
+        let content = fs::read_to_string(&path).unwrap().replace(
+            &task.deadline.format(DEADLINE_DATE_FORMAT).to_string(),
+            &task
+                .deadline
+                .format(LEGACY_DEADLINE_DATE_FORMAT)
+                .to_string(),
+        );
+        fs::write(&path, content).unwrap();
+
+        // WHEN
+        let loaded = Task::load(&path, TaskStatus::Todo).unwrap();
+
+        // THEN
+        assert_eq!(loaded.deadline, task.deadline);
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }
@@ -455,7 +515,10 @@ mod tests {
         assert_eq!(loaded.deadline, expected_deadline);
         assert_eq!(loaded.created_at, task.created_at);
         assert_eq!(loaded.updated_at, task.updated_at);
-        assert!(migrated_content.contains(&format!("deadline: {expected_deadline}")));
+        assert!(migrated_content.contains(&format!(
+            "deadline: {}",
+            expected_deadline.format(DEADLINE_DATE_FORMAT)
+        )));
         assert!(migrated_content.ends_with("## Notes\n\nlegacy body\n"));
 
         fs::remove_dir_all(tasks_dir).unwrap();
@@ -468,9 +531,10 @@ mod tests {
         let task = Task::new_in("invalid deadline".to_string(), tasks_dir.clone());
         task.save().unwrap();
         let path = task.file_path();
-        let content = fs::read_to_string(&path)
-            .unwrap()
-            .replace(&task.deadline.to_string(), "2026-02-30");
+        let content = fs::read_to_string(&path).unwrap().replace(
+            &task.deadline.format(DEADLINE_DATE_FORMAT).to_string(),
+            "2026/02/30",
+        );
         fs::write(&path, content).unwrap();
 
         // WHEN
@@ -506,7 +570,10 @@ mod tests {
         assert!(task.updated_at > before_update);
         let content = fs::read_to_string(task.file_path()).unwrap();
         assert!(content.contains(body));
-        assert!(content.contains(&format!("deadline: {}", task.deadline)));
+        assert!(content.contains(&format!(
+            "deadline: {}",
+            task.deadline.format(DEADLINE_DATE_FORMAT)
+        )));
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use chrono::{Days, Local};
 use crossterm::event::KeyCode;
 use rem_cli::app::App;
-use rem_cli::task::TaskStatus;
+use rem_cli::task::{DEADLINE_DATE_FORMAT, TaskStatus};
 use std::fs;
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -48,7 +48,10 @@ fn adding_task_creates_md_file() {
         .unwrap();
     let content = fs::read_to_string(file_path).unwrap();
     assert_eq!(new_task.deadline, expected_deadline);
-    assert!(content.contains(&format!("deadline: {expected_deadline}")));
+    assert!(content.contains(&format!(
+        "deadline: {}",
+        expected_deadline.format(DEADLINE_DATE_FORMAT)
+    )));
 
     fs::remove_dir_all(tasks_dir).unwrap();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,4 @@
+use chrono::{Days, Local};
 use crossterm::event::KeyCode;
 use rem_cli::app::App;
 use rem_cli::task::TaskStatus;
@@ -41,6 +42,13 @@ fn adding_task_creates_md_file() {
         file_path.to_str().unwrap().contains("/todo/"),
         "md file should be in todo/ directory"
     );
+    let expected_deadline = Local::now()
+        .date_naive()
+        .checked_add_days(Days::new(1))
+        .unwrap();
+    let content = fs::read_to_string(file_path).unwrap();
+    assert_eq!(new_task.deadline, expected_deadline);
+    assert!(content.contains(&format!("deadline: {expected_deadline}")));
 
     fs::remove_dir_all(tasks_dir).unwrap();
 }


### PR DESCRIPTION
## Summary
- add a date-only deadline field to task frontmatter
- assign tomorrow in the local timezone to new and legacy tasks
- display deadlines below task names in dark gray

## Tests
- cargo fmt --check
- cargo test task::tests
- cargo test render::tests
- cargo test --test integration_test