### PR TITLE
Add keymap `gg` and `G`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A TUI (Terminal User Interface) TODO management tool. `rem` stands for "remember
 |-----|--------|
 | `a` | Add a new task |
 | `j` / `k` | Navigate down / up within a status |
+| `G` / `gg` | Navigate to the bottom / top within a status |
 | `h` / `l` | Navigate left / right between statuses |
 | `n` | Move task to next status (PARKING -> TODO -> DOING -> DONE) |
 | `N` | Move task to previous status (DONE -> DOING -> TODO -> PARKING) |

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,7 @@ pub struct App {
     pub error_message: Option<String>,
     pub(crate) tasks_dir: PathBuf,
     pub(crate) persistent_error: Option<String>,
+    pub(crate) pending_g: bool,
 }
 
 impl Default for App {
@@ -66,6 +67,7 @@ impl App {
             error_message: error_message.clone(),
             tasks_dir,
             persistent_error: error_message,
+            pending_g: false,
         }
     }
 
@@ -99,23 +101,36 @@ impl App {
     /// Dispatches a key event to the appropriate handler based on the current input mode.
     pub fn handle_key_event(&mut self, key_code: KeyCode) {
         match self.input_mode {
-            Mode::Normal => match key_code {
-                KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
-                KeyCode::Char('a') => {
-                    self.input_mode = Mode::Editing;
-                    self.input_buffer.clear();
-                    self.input_cursor = 0;
+            Mode::Normal => {
+                if key_code == KeyCode::Char('g') {
+                    if self.pending_g {
+                        self.select_first();
+                        self.pending_g = false;
+                    } else {
+                        self.pending_g = true;
+                    }
+                    return;
                 }
-                KeyCode::Char('j') | KeyCode::Down => self.select_next(),
-                KeyCode::Char('k') | KeyCode::Up => self.select_previous(),
-                KeyCode::Char('h') | KeyCode::Left => self.select_left(),
-                KeyCode::Char('l') | KeyCode::Right => self.select_right(),
-                KeyCode::Char('n') => self.forward_status(),
-                KeyCode::Char('N') => self.backward_status(),
-                KeyCode::Char('d') => self.toggle_done(),
-                KeyCode::Enter => self.open_task(),
-                _ => {}
-            },
+                self.pending_g = false;
+                match key_code {
+                    KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
+                    KeyCode::Char('a') => {
+                        self.input_mode = Mode::Editing;
+                        self.input_buffer.clear();
+                        self.input_cursor = 0;
+                    }
+                    KeyCode::Char('j') | KeyCode::Down => self.select_next(),
+                    KeyCode::Char('k') | KeyCode::Up => self.select_previous(),
+                    KeyCode::Char('h') | KeyCode::Left => self.select_left(),
+                    KeyCode::Char('l') | KeyCode::Right => self.select_right(),
+                    KeyCode::Char('G') => self.select_last(),
+                    KeyCode::Char('n') => self.forward_status(),
+                    KeyCode::Char('N') => self.backward_status(),
+                    KeyCode::Char('d') => self.toggle_done(),
+                    KeyCode::Enter => self.open_task(),
+                    _ => {}
+                }
+            }
             Mode::Editing => match key_code {
                 KeyCode::Enter => {
                     self.add_task();
@@ -193,6 +208,26 @@ impl App {
             .position(|candidate| *candidate == index)
             .unwrap_or(0);
         self.selected_index = status_indices.get(row.saturating_sub(1)).copied();
+    }
+
+    fn select_first(&mut self) {
+        let Some(index) = self.selected_index else {
+            return;
+        };
+        self.selected_index = self
+            .indices_for_status(self.tasks[index].status)
+            .first()
+            .copied();
+    }
+
+    fn select_last(&mut self) {
+        let Some(index) = self.selected_index else {
+            return;
+        };
+        self.selected_index = self
+            .indices_for_status(self.tasks[index].status)
+            .last()
+            .copied();
     }
 
     fn select_left(&mut self) {
@@ -448,6 +483,7 @@ mod tests {
             error_message: None,
             tasks_dir: Task::default_base_dir(),
             persistent_error: None,
+            pending_g: false,
         }
     }
 
@@ -575,6 +611,79 @@ mod tests {
     }
 
     #[test]
+    fn uppercase_g_selects_last_task_in_current_status() {
+        // GIVEN
+        let tasks = vec![
+            create_task("todo one", TaskStatus::Todo),
+            create_task("todo two", TaskStatus::Todo),
+            create_task("todo three", TaskStatus::Todo),
+            create_task("doing", TaskStatus::Doing),
+        ];
+        let mut app = create_app(tasks, Some(0));
+        let expected = app
+            .tasks
+            .iter()
+            .enumerate()
+            .filter_map(|(index, task)| (task.status == TaskStatus::Todo).then_some(index))
+            .next_back();
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('G'));
+
+        // THEN
+        assert_eq!(app.selected_index, expected);
+        assert_eq!(
+            app.tasks[app.selected_index.unwrap()].status,
+            TaskStatus::Todo
+        );
+    }
+
+    #[test]
+    fn double_g_selects_first_task_in_current_status() {
+        // GIVEN
+        let tasks = vec![
+            create_task("parking", TaskStatus::Parking),
+            create_task("todo one", TaskStatus::Todo),
+            create_task("todo two", TaskStatus::Todo),
+            create_task("todo three", TaskStatus::Todo),
+        ];
+        let mut app = create_app(tasks, Some(3));
+        let expected = app
+            .tasks
+            .iter()
+            .position(|task| task.status == TaskStatus::Todo);
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('g'));
+        app.handle_key_event(KeyCode::Char('g'));
+
+        // THEN
+        assert_eq!(app.selected_index, expected);
+        assert_eq!(
+            app.tasks[app.selected_index.unwrap()].status,
+            TaskStatus::Todo
+        );
+    }
+
+    #[test]
+    fn key_after_single_g_performs_its_normal_action() {
+        // GIVEN
+        let tasks = vec![
+            create_task("todo one", TaskStatus::Todo),
+            create_task("todo two", TaskStatus::Todo),
+        ];
+        let mut app = create_app(tasks, Some(0));
+        app.handle_key_event(KeyCode::Char('g'));
+        let expected = Some(1);
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('j'));
+
+        // THEN
+        assert_eq!(app.selected_index, expected);
+    }
+
+    #[test]
     fn hiding_done_selects_nearby_visible_task() {
         // GIVEN
         let tasks = vec![
@@ -648,6 +757,7 @@ mod tests {
             error_message: None,
             tasks_dir,
             persistent_error: None,
+            pending_g: false,
         };
 
         // WHEN

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,10 @@
 use crossterm::event::KeyCode;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use crate::task::{Task, TaskStatus};
+
+const DOUBLE_KEY_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(PartialEq)]
 pub enum Mode {
@@ -23,7 +26,7 @@ pub struct App {
     pub error_message: Option<String>,
     pub(crate) tasks_dir: PathBuf,
     pub(crate) persistent_error: Option<String>,
-    pub(crate) pending_g: bool,
+    pub(crate) pending_g_at: Option<Instant>,
 }
 
 impl Default for App {
@@ -67,7 +70,7 @@ impl App {
             error_message: error_message.clone(),
             tasks_dir,
             persistent_error: error_message,
-            pending_g: false,
+            pending_g_at: None,
         }
     }
 
@@ -103,15 +106,19 @@ impl App {
         match self.input_mode {
             Mode::Normal => {
                 if key_code == KeyCode::Char('g') {
-                    if self.pending_g {
+                    let now = Instant::now();
+                    let is_double_g = self.pending_g_at.is_some_and(|started_at| {
+                        now.saturating_duration_since(started_at) <= DOUBLE_KEY_TIMEOUT
+                    });
+                    if is_double_g {
                         self.select_first();
-                        self.pending_g = false;
+                        self.pending_g_at = None;
                     } else {
-                        self.pending_g = true;
+                        self.pending_g_at = Some(now);
                     }
                     return;
                 }
-                self.pending_g = false;
+                self.pending_g_at = None;
                 match key_code {
                     KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
                     KeyCode::Char('a') => {
@@ -483,7 +490,7 @@ mod tests {
             error_message: None,
             tasks_dir: Task::default_base_dir(),
             persistent_error: None,
-            pending_g: false,
+            pending_g_at: None,
         }
     }
 
@@ -666,6 +673,26 @@ mod tests {
     }
 
     #[test]
+    fn double_g_after_timeout_does_not_select_first_task() {
+        // GIVEN
+        let tasks = vec![
+            create_task("todo one", TaskStatus::Todo),
+            create_task("todo two", TaskStatus::Todo),
+            create_task("todo three", TaskStatus::Todo),
+        ];
+        let mut app = create_app(tasks, Some(2));
+        app.pending_g_at = Some(Instant::now() - DOUBLE_KEY_TIMEOUT - Duration::from_millis(1));
+        let expected = Some(2);
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('g'));
+
+        // THEN
+        assert_eq!(app.selected_index, expected);
+        assert!(app.pending_g_at.is_some());
+    }
+
+    #[test]
     fn key_after_single_g_performs_its_normal_action() {
         // GIVEN
         let tasks = vec![
@@ -757,7 +784,7 @@ mod tests {
             error_message: None,
             tasks_dir,
             persistent_error: None,
-            pending_g: false,
+            pending_g_at: None,
         };
 
         // WHEN

--- a/src/render.rs
+++ b/src/render.rs
@@ -176,7 +176,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         let (message, style) = app.error_message.as_deref().map_or_else(
             || {
                 (
-                    " a: add | j/k: up/down | h/l: left/right | n/N: status | d: toggle done | q: quit ",
+                    " a: add | j/k: up/down | G/gg: bottom/top | h/l: left/right | n/N: status | d: toggle done | q: quit ",
                     Style::default(),
                 )
             },
@@ -207,7 +207,7 @@ mod tests {
             error_message: None,
             tasks_dir: Task::default_base_dir(),
             persistent_error: None,
-            pending_g: false,
+            pending_g_at: None,
         }
     }
 
@@ -253,6 +253,18 @@ mod tests {
         // THEN
         assert!(expected_titles.iter().all(|title| actual.contains(title)));
         assert!(!actual.contains("Preview"));
+    }
+
+    #[test]
+    fn renders_navigation_help() {
+        // GIVEN
+        let expected = "G/gg: bottom/top";
+
+        // WHEN
+        let actual = rendered_text(false);
+
+        // THEN
+        assert!(actual.contains(expected));
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -207,6 +207,7 @@ mod tests {
             error_message: None,
             tasks_dir: Task::default_base_dir(),
             persistent_error: None,
+            pending_g: false,
         }
     }
 


### PR DESCRIPTION
## Summary
Add Vim-style `G` and `gg` keybindings for jumping to the bottom and top of the currently selected status column.

This change tracks a pending `g` input in the application state, keeps subsequent non-`g` key actions working normally, adds unit tests for the new navigation behavior, and documents the keybindings in the README.
