### PR TITLE
Update app version number when git tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,20 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       commit_sha: ${{ steps.update.outputs.commit_sha }}
       version: ${{ steps.update.outputs.version }}
@@ -30,34 +36,69 @@ jobs:
         id: update
         shell: bash
         run: |
+          set -euo pipefail
+
           tag="${GITHUB_REF_NAME}"
           if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid release tag: ${tag}" >&2
             exit 1
           fi
 
-          tag_commit="$(git rev-parse HEAD)"
-          main_commit="$(git rev-parse origin/main)"
-          if [[ "${tag_commit}" != "${main_commit}" ]]; then
-            echo "Release tag must point to the latest commit on main." >&2
-            exit 1
+          version="${tag#v}"
+          git fetch --force origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/tags/${tag}:refs/tags/${tag}"
+
+          tag_commit="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          main_commit="$(git rev-parse refs/remotes/origin/main)"
+          git checkout --detach "${tag_commit}"
+          current_version="$(sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}' Cargo.toml)"
+
+          if [[ "${current_version}" == "${version}" ]]; then
+            release_commit="${tag_commit}"
+          elif [[ "${tag_commit}" == "${main_commit}" ]]; then
+            release_commit=""
+          else
+            main_parent="$(git rev-parse "${main_commit}^")"
+            main_version="$(git show "${main_commit}:Cargo.toml" | sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}')"
+            main_subject="$(git show -s --format=%s "${main_commit}")"
+            unexpected_files="$(git diff --name-only "${tag_commit}" "${main_commit}" | grep -Ev '^(Cargo.toml|Cargo.lock)$' || true)"
+
+            if [[ "${main_parent}" == "${tag_commit}" \
+              && "${main_version}" == "${version}" \
+              && "${main_subject}" == "chore: bump version to ${version}" \
+              && -z "${unexpected_files}" ]]; then
+              release_commit="${main_commit}"
+            else
+              echo "Release tag must point to the latest commit on main." >&2
+              exit 1
+            fi
           fi
 
-          version="${tag#v}"
-          sed -i.bak -E '/^\[package\]$/,/^\[/{s/^version = "[^"]+"$/version = "'"${version}"'"/;}' Cargo.toml
-          rm Cargo.toml.bak
-          cargo update -p rem-cli
-          cargo metadata --locked --no-deps --format-version 1 > /dev/null
+          if [[ -z "${release_commit}" ]]; then
+            sed -i.bak -E '/^\[package\]$/,/^\[/{s/^version = "[^"]+"$/version = "'"${version}"'"/;}' Cargo.toml
+            rm Cargo.toml.bak
+            cargo update -p rem-cli
+            cargo metadata --locked --no-deps --format-version 1 > /dev/null
 
-          if ! git diff --quiet -- Cargo.toml Cargo.lock; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add Cargo.toml Cargo.lock
             git commit -m "chore: bump version to ${version}"
             git push origin HEAD:main
+            release_commit="$(git rev-parse HEAD)"
           fi
 
-          echo "commit_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          remote_tag_ref="$(git rev-parse "refs/tags/${tag}")"
+          remote_tag_commit="$(git rev-parse "${remote_tag_ref}^{commit}")"
+          if [[ "${remote_tag_commit}" != "${release_commit}" ]]; then
+            git update-ref "refs/tags/${tag}" "${release_commit}"
+            git push \
+              --force-with-lease="refs/tags/${tag}:${remote_tag_ref}" \
+              origin "refs/tags/${tag}"
+          fi
+
+          echo "commit_sha=${release_commit}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
   build:
@@ -129,6 +170,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,16 +72,24 @@ jobs:
             && git merge-base --is-ancestor "${tag_commit}" "${main_commit}"; then
             release_commit="${tag_commit}"
           else
-            main_parent="$(git rev-parse "${main_commit}^")"
-            main_version="$(git show "${main_commit}:Cargo.toml" | sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}')"
-            main_subject="$(git show -s --format=%s "${main_commit}")"
-            unexpected_files="$(git diff --name-only "${tag_commit}" "${main_commit}" | grep -Ev '^(Cargo.toml|Cargo.lock)$' || true)"
+            if ! git merge-base --is-ancestor "${tag_commit}" "${main_commit}"; then
+              echo "Release tag must point to a commit on main." >&2
+              exit 1
+            fi
 
-            if [[ "${main_parent}" == "${tag_commit}" \
-              && "${main_version}" == "${version}" \
-              && "${main_subject}" == "chore: bump version to ${version}" \
+            version_commit="$(
+              git rev-list --reverse --ancestry-path "${tag_commit}..${main_commit}" | sed -n '1p'
+            )"
+            version_parent="$(git rev-parse "${version_commit}^")"
+            committed_version="$(git show "${version_commit}:Cargo.toml" | sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}')"
+            version_subject="$(git show -s --format=%s "${version_commit}")"
+            unexpected_files="$(git diff --name-only "${tag_commit}" "${version_commit}" | grep -Ev '^(Cargo.toml|Cargo.lock)$' || true)"
+
+            if [[ "${version_parent}" == "${tag_commit}" \
+              && "${committed_version}" == "${version}" \
+              && "${version_subject}" == "chore: bump version to ${version}" \
               && -z "${unexpected_files}" ]]; then
-              release_commit="${main_commit}"
+              release_commit="${version_commit}"
             else
               echo "Release tag must point to the latest commit on main." >&2
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,56 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.update.outputs.commit_sha }}
+      version: ${{ steps.update.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update version
+        id: update
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: ${tag}" >&2
+            exit 1
+          fi
+
+          tag_commit="$(git rev-parse HEAD)"
+          main_commit="$(git rev-parse origin/main)"
+          if [[ "${tag_commit}" != "${main_commit}" ]]; then
+            echo "Release tag must point to the latest commit on main." >&2
+            exit 1
+          fi
+
+          version="${tag#v}"
+          sed -i.bak -E '/^\[package\]$/,/^\[/{s/^version = "[^"]+"$/version = "'"${version}"'"/;}' Cargo.toml
+          rm Cargo.toml.bak
+          cargo update -p rem-cli
+          cargo metadata --locked --no-deps --format-version 1 > /dev/null
+
+          if ! git diff --quiet -- Cargo.toml Cargo.lock; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add Cargo.toml Cargo.lock
+            git commit -m "chore: bump version to ${version}"
+            git push origin HEAD:main
+          fi
+
+          echo "commit_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
   build:
+    needs: update-version
     strategy:
       matrix:
         include:
@@ -36,7 +85,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.update-version.outputs.commit_sha }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -54,13 +105,23 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
+      - name: Verify version
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          actual_version="$(target/${{ matrix.target }}/release/${{ matrix.artifact_name }} --version)"
+          expected_version="rem ${{ needs.update-version.outputs.version }}"
+          if [ "${actual_version}" != "${expected_version}" ]; then
+            echo "Expected ${expected_version}, but got ${actual_version}." >&2
+            exit 1
+          fi
+
       - name: Create tarball
         run: |
           cd target/${{ matrix.target }}/release
           tar -czvf ../../../${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact_name }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ matrix.asset_name }}.tar.gz
@@ -70,15 +131,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: artifacts/**/*.tar.gz
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,10 @@ jobs:
             else
               release_commit=""
             fi
+          elif [[ "${GITHUB_RUN_ATTEMPT:-1}" -gt 1 \
+            && "${current_version}" == "${version}" ]] \
+            && git merge-base --is-ancestor "${tag_commit}" "${main_commit}"; then
+            release_commit="${tag_commit}"
           else
             main_parent="$(git rev-parse "${main_commit}^")"
             main_version="$(git show "${main_commit}:Cargo.toml" | sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -49,15 +49,24 @@ jobs:
             "+refs/heads/main:refs/remotes/origin/main" \
             "+refs/tags/${tag}:refs/tags/${tag}"
 
-          tag_commit="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          tag_ref="$(git rev-parse "refs/tags/${tag}")"
+          tag_type="$(git cat-file -t "${tag_ref}")"
+          if [[ "${tag_type}" != "commit" ]]; then
+            echo "Release tags must be lightweight tags." >&2
+            exit 1
+          fi
+
+          tag_commit="${tag_ref}"
           main_commit="$(git rev-parse refs/remotes/origin/main)"
           git checkout --detach "${tag_commit}"
           current_version="$(sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}' Cargo.toml)"
 
-          if [[ "${current_version}" == "${version}" ]]; then
-            release_commit="${tag_commit}"
-          elif [[ "${tag_commit}" == "${main_commit}" ]]; then
-            release_commit=""
+          if [[ "${tag_commit}" == "${main_commit}" ]]; then
+            if [[ "${current_version}" == "${version}" ]]; then
+              release_commit="${tag_commit}"
+            else
+              release_commit=""
+            fi
           else
             main_parent="$(git rev-parse "${main_commit}^")"
             main_version="$(git show "${main_commit}:Cargo.toml" | sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}')"
@@ -89,9 +98,40 @@ jobs:
             release_commit="$(git rev-parse HEAD)"
           fi
 
+          git checkout --detach "${release_commit}"
+          manifest_version="$(sed -n '/^\[package\]$/,/^\[/{s/^version = "\([^"]*\)"$/\1/p;}' Cargo.toml)"
+          lock_version="$(
+            awk '
+              $0 == "[[package]]" {
+                package = 1
+                name = ""
+                version = ""
+                next
+              }
+              package && /^name = "/ {
+                name = $0
+                sub(/^name = "/, "", name)
+                sub(/"$/, "", name)
+              }
+              package && /^version = "/ {
+                version = $0
+                sub(/^version = "/, "", version)
+                sub(/"$/, "", version)
+              }
+              package && name == "rem-cli" && version != "" {
+                print version
+                exit
+              }
+            ' Cargo.lock
+          )"
+          if [[ "${manifest_version}" != "${version}" || "${lock_version}" != "${version}" ]]; then
+            echo "Cargo.toml and Cargo.lock must match release version ${version}." >&2
+            exit 1
+          fi
+          cargo metadata --locked --no-deps --format-version 1 > /dev/null
+
           remote_tag_ref="$(git rev-parse "refs/tags/${tag}")"
-          remote_tag_commit="$(git rev-parse "${remote_tag_ref}^{commit}")"
-          if [[ "${remote_tag_commit}" != "${release_commit}" ]]; then
+          if [[ "${remote_tag_ref}" != "${release_commit}" ]]; then
             git update-ref "refs/tags/${tag}" "${release_commit}"
             git push \
               --force-with-lease="refs/tags/${tag}:${remote_tag_ref}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## 概要
Gitの`vX.Y.Z`形式の軽量タグ作成をトリガーに、`Cargo.toml`と`Cargo.lock`のアプリバージョンを自動更新する処理を既存のリリースワークフローへ追加します。

更新後のコミットへタグを安全に移動し、そのコミットから各プラットフォーム向けバイナリをビルドすることで、GitHub Releaseのソースと配布成果物を一致させます。また、途中失敗後の再実行やタグ更新の復旧、バージョン整合性の検証、リリース処理の直列化にも対応します。

あわせて、GitHub Actionsの`checkout`、`upload-artifact`、`download-artifact`、`action-gh-release`を最新メジャーバージョンへ更新します。

## 背景
これまではリリースタグ作成前に`Cargo.toml`と`Cargo.lock`のバージョンを手動更新する必要があり、更新漏れやタグと配布バイナリのバージョン不一致が発生する可能性がありました。

タグ作成をリリースの起点としてバージョン更新からGitHub Release作成までを自動化しつつ、ビルド失敗やタグ移動失敗が発生しても同じワークフローを安全に再実行できるようにします。