### PR TITLE
Apply sprit cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Tasks are stored as markdown files under `~/.rem-cli/tasks/` with directory-base
 ```
 
 - Status is determined by which directory the file resides in (not by frontmatter)
-- Frontmatter contains: `id`, `name`, `created_at`, `updated_at`, `deadline` in `yyyy/MM/dd` format (no `status` field)
+- Frontmatter contains: `id`, `name`, `created_at`, `updated_at`, optional `completed_at`, and `deadline` in `yyyy/MM/dd` format (no `status` field)
+- Task timestamps use local `NaiveDateTime` values without timezone information
 - Status changes move the file between directories via `fs::rename`
 
 ## Key Patterns
@@ -50,7 +51,8 @@ Tasks are stored as markdown files under `~/.rem-cli/tasks/` with directory-base
 - Clean terminal restoration on exit (disable raw mode, leave alternate screen)
 - Two input modes: `Normal` (navigation/actions) and `Editing` (text input for new tasks)
 - PARKING tasks are loaded after the first frame is rendered
-- DONE tasks are lazy-loaded on demand (`d` key toggles) to keep startup fast
+- DONE tasks are lazy-loaded on demand (`d` key toggles) and filtered by completion week
+- DONE review weeks run from Monday through Sunday; `[` / `]` navigate weeks
 - Status columns are displayed horizontally as PARKING / TODO / DOING / DONE
 - DONE is hidden by default and toggled with the `d` key
 - `j` / `k` move within a status column, while `h` / `l` move between non-empty columns

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A TUI (Terminal User Interface) TODO management tool. `rem` stands for "remember
 ## 🚀 Features
 
 - **Four-column status management** - PARKING / TODO / DOING / DONE
+- **Weekly DONE reviews** - Review completed tasks in Monday-to-Sunday intervals
 - **Keyboard-driven workflow** - Add, navigate, and update tasks without touching the mouse
 - **Lazy loading** - PARKING loads after the first frame and DONE loads on demand
 - **Neovim integration** - Press Enter to open and edit a task file in neovim
@@ -40,7 +41,8 @@ A TUI (Terminal User Interface) TODO management tool. `rem` stands for "remember
 | `h` / `l` | Navigate left / right between statuses |
 | `n` | Move task to next status (PARKING -> TODO -> DOING -> DONE) |
 | `N` | Move task to previous status (DONE -> DOING -> TODO -> PARKING) |
-| `d` | Toggle DONE tasks visibility |
+| `d` | Toggle this week's DONE tasks |
+| `[` / `]` | Show the previous / next DONE week |
 | `Enter` | Open task file in neovim |
 | `q` / `Esc` | Quit |
 
@@ -90,7 +92,7 @@ Tasks are stored as markdown files under `~/.rem-cli/tasks/` with directories re
     <uuid>.md
 ```
 
-Each file contains YAML frontmatter with task metadata. You can freely edit, back up, or version control these files.
+Each file contains YAML frontmatter with task metadata. `created_at` and `updated_at` are stored as local date-times without timezone information. DONE tasks also contain `completed_at`, which is used for weekly reviews. You can freely edit, back up, or version control these files.
 
 ## 🌟 Community
 

--- a/docs/reviews/codereview_PR18_20260615.md
+++ b/docs/reviews/codereview_PR18_20260615.md
@@ -1,0 +1,16 @@
+# The result of review
+Apply sprit cycle
+
+## ❌CRITICAL
+No findings.
+
+## 🔴HIGH
+No findings.
+
+## 🟡MEDIUM
+### Comment1: An empty DONE week is represented by clearing task selection
+`src/render.rs` interprets `selected_index == None` as an active empty DONE column. This renders the expected border, but horizontal and vertical navigation cannot distinguish that state from having no active column. A dedicated selected-column state would make empty-column navigation consistent.
+
+## 🔵LOW
+### Comment1: Weekly loading scans and migrates the complete DONE history
+`Task::load_done_for_week_from` loads every DONE file before filtering by `completed_at`. This preserves the current storage design but can make weekly navigation slower as DONE history grows.

--- a/src/app.rs
+++ b/src/app.rs
@@ -366,11 +366,22 @@ impl App {
             return;
         }
         self.error_message = self.persistent_error.clone();
-        if next_status == TaskStatus::Done && !self.done_loaded {
-            self.tasks.retain(|task| task.id != id);
-            self.tasks = Task::sort(self.tasks.clone());
-            self.selected_index = self.nearby_selection(previous_status, previous_row);
-            return;
+        if next_status == TaskStatus::Done {
+            let done_week_end = self
+                .done_week_start
+                .checked_add_days(Days::new(7))
+                .expect("done week end should be a valid date");
+            let belongs_to_visible_done_week = self.done_loaded
+                && self.tasks[index].completed_at.is_some_and(|completed_at| {
+                    let completed_date = completed_at.date();
+                    completed_date >= self.done_week_start && completed_date < done_week_end
+                });
+            if !belongs_to_visible_done_week {
+                self.tasks.retain(|task| task.id != id);
+                self.tasks = Task::sort(self.tasks.clone());
+                self.selected_index = self.nearby_selection(previous_status, previous_row);
+                return;
+            }
         }
         self.tasks = Task::sort(self.tasks.clone());
         self.selected_index = self.tasks.iter().position(|task| task.id == id);
@@ -910,6 +921,45 @@ mod tests {
 
         // THEN
         assert_eq!(app.done_week_start, expected);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn completing_task_during_past_week_review_keeps_it_out_of_done_column() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let mut target = Task::new_in("current completion".to_string(), tasks_dir.clone());
+        target.save().unwrap();
+        target.update_status(TaskStatus::Doing).unwrap();
+        let neighbor = Task::new_in("visible neighbor".to_string(), tasks_dir.clone());
+        neighbor.save().unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        app.done_loaded = true;
+        app.done_week_start = Task::week_start(Local::now().date_naive())
+            .checked_sub_days(Days::new(7))
+            .unwrap();
+        app.selected_index = app
+            .tasks
+            .iter()
+            .position(|task| task.name == "current completion");
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('n'));
+
+        // THEN
+        assert!(
+            app.tasks
+                .iter()
+                .all(|task| task.name != "current completion")
+        );
+        let selected_name = app
+            .selected_index
+            .and_then(|index| app.tasks.get(index))
+            .map(|task| task.name.as_str());
+        assert_eq!(selected_name, Some("visible neighbor"));
+        let done_path = tasks_dir.join("done").join(format!("{}.md", target.id));
+        assert!(done_path.exists());
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use chrono::{Days, Local, NaiveDate};
 use crossterm::event::KeyCode;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -22,6 +23,7 @@ pub struct App {
     pub selected_index: Option<usize>,
     pub parking_loaded: bool,
     pub done_loaded: bool,
+    pub done_week_start: NaiveDate,
     pub open_file: Option<PathBuf>,
     pub error_message: Option<String>,
     pub(crate) tasks_dir: PathBuf,
@@ -46,6 +48,7 @@ impl App {
 
     /// Creates an `App` using the provided task storage directory.
     pub fn with_tasks_dir(tasks_dir: PathBuf) -> Self {
+        let done_week_start = Task::week_start(Local::now().date_naive());
         let todo_result = Task::load_todo_from(&tasks_dir);
         let doing_result = Task::load_doing_from(&tasks_dir);
         let error_message = todo_result
@@ -66,6 +69,7 @@ impl App {
             selected_index,
             parking_loaded: false,
             done_loaded: false,
+            done_week_start,
             open_file: None,
             error_message: error_message.clone(),
             tasks_dir,
@@ -134,6 +138,8 @@ impl App {
                     KeyCode::Char('n') => self.forward_status(),
                     KeyCode::Char('N') => self.backward_status(),
                     KeyCode::Char('d') => self.toggle_done(),
+                    KeyCode::Char('[') => self.show_previous_done_week(),
+                    KeyCode::Char(']') => self.show_next_done_week(),
                     KeyCode::Enter => self.open_task(),
                     _ => {}
                 }
@@ -433,24 +439,17 @@ impl App {
             });
             self.tasks.retain(|t| t.status != TaskStatus::Done);
             self.done_loaded = false;
+            self.done_week_start = Task::week_start(Local::now().date_naive());
             if selection.is_some_and(|(status, _)| status == TaskStatus::Done) {
                 self.selected_index =
                     selection.and_then(|(_, row)| self.nearby_selection(TaskStatus::Doing, row));
             }
         } else {
-            let done_tasks = match Task::load_done_from(&self.tasks_dir) {
-                Ok(tasks) => tasks,
-                Err(error) => {
-                    self.error_message = Some(
-                        self.error_with_persistent(format!("Failed to load DONE tasks: {error}")),
-                    );
-                    return;
-                }
-            };
-            self.tasks.extend(done_tasks);
-            self.tasks = Task::sort(self.tasks.clone());
+            self.done_week_start = Task::week_start(Local::now().date_naive());
+            if !self.load_done_week() {
+                return;
+            }
             self.done_loaded = true;
-            self.error_message = self.persistent_error.clone();
         }
         if self.tasks.is_empty() {
             self.selected_index = None;
@@ -459,6 +458,80 @@ impl App {
         {
             self.selected_index = Some(self.tasks.len() - 1);
         }
+    }
+
+    fn show_previous_done_week(&mut self) {
+        if !self.done_loaded {
+            return;
+        }
+        let previous_week_start = self
+            .done_week_start
+            .checked_sub_days(Days::new(7))
+            .expect("previous week should be a valid date");
+        let current_week_start = self.done_week_start;
+        self.done_week_start = previous_week_start;
+        if !self.load_done_week() {
+            self.done_week_start = current_week_start;
+            return;
+        }
+        self.select_done_column();
+    }
+
+    fn show_next_done_week(&mut self) {
+        if !self.done_loaded {
+            return;
+        }
+        let current_week_start = Task::week_start(Local::now().date_naive());
+        let next_week_start = self
+            .done_week_start
+            .checked_add_days(Days::new(7))
+            .expect("next week should be a valid date");
+        if next_week_start > current_week_start {
+            return;
+        }
+        let current_done_week_start = self.done_week_start;
+        self.done_week_start = next_week_start;
+        if !self.load_done_week() {
+            self.done_week_start = current_done_week_start;
+            return;
+        }
+        self.select_done_column();
+    }
+
+    fn load_done_week(&mut self) -> bool {
+        let selected_id = self
+            .selected_index
+            .and_then(|index| self.tasks.get(index))
+            .map(|task| task.id);
+        let done_tasks = match Task::load_done_for_week_from(&self.tasks_dir, self.done_week_start)
+        {
+            Ok(tasks) => tasks,
+            Err(error) => {
+                self.error_message =
+                    Some(self.error_with_persistent(format!("Failed to load DONE tasks: {error}")));
+                return false;
+            }
+        };
+        self.tasks.retain(|task| task.status != TaskStatus::Done);
+        self.tasks.extend(done_tasks);
+        self.tasks = Task::sort(self.tasks.clone());
+        self.selected_index = selected_id
+            .and_then(|id| self.tasks.iter().position(|task| task.id == id))
+            .or_else(|| {
+                self.tasks
+                    .iter()
+                    .position(|task| task.status == TaskStatus::Done)
+            })
+            .or_else(|| (!self.tasks.is_empty()).then_some(0));
+        self.error_message = self.persistent_error.clone();
+        true
+    }
+
+    fn select_done_column(&mut self) {
+        self.selected_index = self
+            .tasks
+            .iter()
+            .position(|task| task.status == TaskStatus::Done);
     }
 
     fn error_with_persistent(&self, error: String) -> String {
@@ -486,6 +559,7 @@ mod tests {
             selected_index,
             parking_loaded: true,
             done_loaded: false,
+            done_week_start: Task::week_start(Local::now().date_naive()),
             open_file: None,
             error_message: None,
             tasks_dir: Task::default_base_dir(),
@@ -731,6 +805,116 @@ mod tests {
     }
 
     #[test]
+    fn opening_done_shows_only_current_week_tasks() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let current_week_start = Task::week_start(Local::now().date_naive());
+        let completed_dates = [
+            ("current done", current_week_start),
+            (
+                "previous done",
+                current_week_start.checked_sub_days(Days::new(1)).unwrap(),
+            ),
+        ];
+        completed_dates
+            .into_iter()
+            .map(|(name, date)| {
+                let mut task = Task::new_in(name.to_string(), tasks_dir.clone());
+                task.status = TaskStatus::Done;
+                task.completed_at = date.and_hms_opt(12, 0, 0);
+                task
+            })
+            .try_for_each(|task| task.save())
+            .unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        let expected = ["current done"];
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('d'));
+
+        // THEN
+        let actual = app
+            .tasks
+            .iter()
+            .filter(|task| task.status == TaskStatus::Done)
+            .map(|task| task.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+        assert_eq!(app.done_week_start, current_week_start);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn left_bracket_shows_previous_done_week() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let current_week_start = Task::week_start(Local::now().date_naive());
+        let previous_week_start = current_week_start.checked_sub_days(Days::new(7)).unwrap();
+        let mut task = Task::new_in("previous done".to_string(), tasks_dir.clone());
+        task.status = TaskStatus::Done;
+        task.completed_at = previous_week_start.and_hms_opt(12, 0, 0);
+        task.save().unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        app.handle_key_event(KeyCode::Char('d'));
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('['));
+
+        // THEN
+        let actual = app
+            .tasks
+            .iter()
+            .find(|task| task.status == TaskStatus::Done)
+            .map(|task| task.name.as_str());
+        assert_eq!(actual, Some("previous done"));
+        assert_eq!(app.done_week_start, previous_week_start);
+        assert_eq!(
+            app.selected_index.map(|index| app.tasks[index].status),
+            Some(TaskStatus::Done)
+        );
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn changing_to_empty_done_week_clears_task_selection() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let mut todo = Task::new_in("visible todo".to_string(), tasks_dir.clone());
+        todo.save().unwrap();
+        todo.status = TaskStatus::Parking;
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        app.handle_key_event(KeyCode::Char('d'));
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('['));
+
+        // THEN
+        assert_eq!(app.selected_index, None);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn right_bracket_does_not_move_beyond_current_week() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        fs::create_dir_all(&tasks_dir).unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        app.handle_key_event(KeyCode::Char('d'));
+        let expected = app.done_week_start;
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char(']'));
+
+        // THEN
+        assert_eq!(app.done_week_start, expected);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
     fn editing_cursor_moves_and_inserts_at_selected_position() {
         // GIVEN
         let mut app = create_app(Vec::new(), None);
@@ -780,6 +964,7 @@ mod tests {
             selected_index: Some(0),
             parking_loaded: true,
             done_loaded: false,
+            done_week_start: Task::week_start(Local::now().date_naive()),
             open_file: None,
             error_message: None,
             tasks_dir,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
 use crate::app::{App, Mode};
-use crate::task::{DEADLINE_DATE_FORMAT, Task, TaskStatus};
-use chrono::{Local, NaiveDate};
+use crate::task::{DEADLINE_DATE_FORMAT, TASK_DATETIME_FORMAT, Task, TaskStatus};
+use chrono::{Days, Local, NaiveDate};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
@@ -53,12 +53,23 @@ fn task_text(task: &Task, width: usize, today: NaiveDate, is_selected: bool) -> 
         format!("Deadline: {}", task.deadline.format(DEADLINE_DATE_FORMAT)),
         Style::default().fg(deadline_color),
     );
+    let completed = task.completed_at.map(|completed_at| {
+        Line::styled(
+            format!("Completed: {}", completed_at.format(TASK_DATETIME_FORMAT)),
+            Style::default().fg(if is_selected {
+                Color::Gray
+            } else {
+                Color::DarkGray
+            }),
+        )
+    });
     Text::from(
         wrap_task_name(task.name.as_str(), width)
             .lines
             .into_iter()
             .map(|line| line.patch_style(name_style))
             .chain([deadline])
+            .chain(completed)
             .collect::<Vec<_>>(),
     )
 }
@@ -85,17 +96,28 @@ pub fn render(frame: &mut Frame, app: &App) {
     };
 
     let statuses = if app.done_loaded {
+        let done_week_end = app
+            .done_week_start
+            .checked_add_days(Days::new(6))
+            .expect("done week end should be a valid date");
         vec![
-            (TaskStatus::Parking, " PARKING "),
-            (TaskStatus::Todo, " TODO "),
-            (TaskStatus::Doing, " DOING "),
-            (TaskStatus::Done, " DONE "),
+            (TaskStatus::Parking, " PARKING ".to_string()),
+            (TaskStatus::Todo, " TODO ".to_string()),
+            (TaskStatus::Doing, " DOING ".to_string()),
+            (
+                TaskStatus::Done,
+                format!(
+                    " DONE {}-{} ",
+                    app.done_week_start.format(DEADLINE_DATE_FORMAT),
+                    done_week_end.format(DEADLINE_DATE_FORMAT)
+                ),
+            ),
         ]
     } else {
         vec![
-            (TaskStatus::Parking, " PARKING "),
-            (TaskStatus::Todo, " TODO "),
-            (TaskStatus::Doing, " DOING "),
+            (TaskStatus::Parking, " PARKING ".to_string()),
+            (TaskStatus::Todo, " TODO ".to_string()),
+            (TaskStatus::Doing, " DOING ".to_string()),
         ]
     };
     let constraints = vec![Constraint::Ratio(1, statuses.len() as u32); statuses.len()];
@@ -123,7 +145,9 @@ pub fn render(frame: &mut Frame, app: &App) {
                 ))
             })
             .collect();
-        let border_style = if selected_in_group.is_some() {
+        let is_empty_done_selected =
+            *status == TaskStatus::Done && app.done_loaded && app.selected_index.is_none();
+        let border_style = if selected_in_group.is_some() || is_empty_done_selected {
             Style::default().fg(Color::Green)
         } else {
             Style::default()
@@ -131,7 +155,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         let list = List::new(items)
             .block(
                 Block::default()
-                    .title(*title)
+                    .title(title.as_str())
                     .title_style(status_title_style(*status))
                     .borders(Borders::ALL)
                     .border_style(border_style),
@@ -176,7 +200,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         let (message, style) = app.error_message.as_deref().map_or_else(
             || {
                 (
-                    " a: add | j/k: up/down | G/gg: bottom/top | h/l: left/right | n/N: status | d: toggle done | q: quit ",
+                    " a: add | j/k: up/down | G/gg: bottom/top | h/l: left/right | n/N: status | d: done | [/]: done week | q: quit ",
                     Style::default(),
                 )
             },
@@ -203,6 +227,7 @@ mod tests {
             selected_index: None,
             parking_loaded: false,
             done_loaded,
+            done_week_start: Task::week_start(Local::now().date_naive()),
             open_file: None,
             error_message: None,
             tasks_dir: Task::default_base_dir(),
@@ -253,6 +278,51 @@ mod tests {
         // THEN
         assert!(expected_titles.iter().all(|title| actual.contains(title)));
         assert!(!actual.contains("Preview"));
+    }
+
+    #[test]
+    fn renders_done_week_period() {
+        // GIVEN
+        let mut app = create_app(true);
+        app.done_week_start = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+        let backend = TestBackend::new(160, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let expected = "DONE 2026/06/15-2026/06/21";
+
+        // WHEN
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+
+        // THEN
+        let buffer = terminal.backend().buffer();
+        let actual = (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .filter_map(|x| buffer.cell((x, y)))
+                    .map(|cell| cell.symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(actual.contains(expected));
+    }
+
+    #[test]
+    fn renders_empty_done_column_as_selected_after_week_change() {
+        // GIVEN
+        let mut app = create_app(true);
+        app.selected_index = None;
+        let backend = TestBackend::new(160, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // WHEN
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+
+        // THEN
+        let buffer = terminal.backend().buffer();
+        let done_border = buffer
+            .cell((buffer.area.width - 1, 1))
+            .expect("DONE border should exist");
+        assert_eq!(done_border.fg, Color::Green);
     }
 
     #[test]
@@ -345,6 +415,26 @@ mod tests {
 
         // THEN
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn task_text_displays_completed_datetime() {
+        // GIVEN
+        let mut task = Task::new("completed task".to_string());
+        let completed_at = NaiveDate::from_ymd_opt(2026, 6, 15)
+            .unwrap()
+            .and_hms_opt(10, 30, 45)
+            .unwrap();
+        task.status = TaskStatus::Done;
+        task.completed_at = Some(completed_at);
+        let today = task.deadline;
+        let expected = format!("Completed: {}", completed_at.format(TASK_DATETIME_FORMAT));
+
+        // WHEN
+        let actual = task_text(&task, 30, today, false);
+
+        // THEN
+        assert_eq!(actual.lines.last().unwrap().to_string(), expected);
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Days, Local, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, Days, Local, NaiveDate, NaiveDateTime};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io;
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 pub const DEADLINE_DATE_FORMAT: &str = "%Y/%m/%d";
+pub const TASK_DATETIME_FORMAT: &str = "%Y/%m/%d %H:%M:%S";
 const LEGACY_DEADLINE_DATE_FORMAT: &str = "%Y-%m-%d";
 
 /// Represents the lifecycle status of a task.
@@ -36,8 +37,22 @@ impl TaskStatus {
 struct TaskFrontmatter {
     id: Uuid,
     name: String,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    completed_at: Option<NaiveDateTime>,
+    #[serde(default)]
+    deadline: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StoredTaskFrontmatter {
+    id: Uuid,
+    name: String,
+    created_at: String,
+    updated_at: String,
+    #[serde(default)]
+    completed_at: Option<String>,
     #[serde(default)]
     deadline: Option<String>,
 }
@@ -48,8 +63,9 @@ pub struct Task {
     pub id: Uuid,
     pub name: String,
     pub status: TaskStatus,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+    pub completed_at: Option<NaiveDateTime>,
     pub deadline: NaiveDate,
     base_dir: PathBuf,
 }
@@ -71,6 +87,20 @@ impl Task {
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
     }
 
+    fn parse_datetime(value: &str) -> io::Result<(NaiveDateTime, bool)> {
+        if let Ok(datetime) = NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f") {
+            return Ok((datetime, false));
+        }
+        DateTime::parse_from_rfc3339(value)
+            .map(|datetime| (datetime.naive_local(), true))
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+
+    pub fn week_start(date: NaiveDate) -> NaiveDate {
+        date.checked_sub_days(Days::new(date.weekday().num_days_from_monday().into()))
+            .expect("week start should be a valid date")
+    }
+
     /// Creates a new task with the given name and TODO status.
     pub fn new(name: String) -> Self {
         Self::new_in(name, Self::default_base_dir())
@@ -78,13 +108,14 @@ impl Task {
 
     /// Creates a new task under the provided task storage directory.
     pub fn new_in(name: String, base_dir: PathBuf) -> Self {
-        let now = Utc::now();
+        let now = Local::now().naive_local();
         Self {
             id: Uuid::new_v4(),
             name,
             status: TaskStatus::Todo,
             created_at: now,
             updated_at: now,
+            completed_at: None,
             deadline: Self::tomorrow_deadline(),
             base_dir,
         }
@@ -112,6 +143,7 @@ impl Task {
             name: self.name.clone(),
             created_at: self.created_at,
             updated_at: self.updated_at,
+            completed_at: self.completed_at,
             deadline: Some(self.deadline.format(DEADLINE_DATE_FORMAT).to_string()),
         }
     }
@@ -133,21 +165,39 @@ impl Task {
             .split("---")
             .next()
             .unwrap_or("");
-        let fm: TaskFrontmatter = serde_yaml::from_str(yaml)
+        let fm: StoredTaskFrontmatter = serde_yaml::from_str(yaml)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let (created_at, created_at_needs_migration) = Self::parse_datetime(&fm.created_at)?;
+        let (updated_at, updated_at_needs_migration) = Self::parse_datetime(&fm.updated_at)?;
+        let parsed_completed_at = fm
+            .completed_at
+            .as_deref()
+            .map(Self::parse_datetime)
+            .transpose()?;
+        let completed_at_needs_migration = parsed_completed_at
+            .as_ref()
+            .is_some_and(|(_, needs_migration)| *needs_migration);
+        let completed_at = parsed_completed_at.map(|(datetime, _)| datetime);
         let parsed_deadline = fm
             .deadline
             .as_deref()
             .map(Self::parse_deadline)
             .transpose()?;
-        let (deadline, needs_migration) =
+        let (deadline, deadline_needs_migration) =
             parsed_deadline.unwrap_or_else(|| (Self::tomorrow_deadline(), true));
+        let completed_at = completed_at.or((status == TaskStatus::Done).then_some(updated_at));
+        let needs_migration = created_at_needs_migration
+            || updated_at_needs_migration
+            || completed_at_needs_migration
+            || deadline_needs_migration
+            || (status == TaskStatus::Done && fm.completed_at.is_none());
         let task = Self {
             id: fm.id,
             name: fm.name,
             status,
-            created_at: fm.created_at,
-            updated_at: fm.updated_at,
+            created_at,
+            updated_at,
+            completed_at,
             deadline,
             base_dir: path
                 .parent()
@@ -207,6 +257,26 @@ impl Task {
         Self::load_by_status(base_dir, &[TaskStatus::Done])
     }
 
+    pub fn load_done_for_week_from(
+        base_dir: &Path,
+        week_start: NaiveDate,
+    ) -> io::Result<Vec<Self>> {
+        let week_end = week_start
+            .checked_add_days(Days::new(7))
+            .expect("week end should be a valid date");
+        Self::load_done_from(base_dir).map(|tasks| {
+            tasks
+                .into_iter()
+                .filter(|task| {
+                    task.completed_at.is_some_and(|completed_at| {
+                        let completed_date = completed_at.date();
+                        completed_date >= week_start && completed_date < week_end
+                    })
+                })
+                .collect()
+        })
+    }
+
     /// Loads tasks from the directories corresponding to the given statuses, sorted by `created_at`.
     fn load_by_status(base_dir: &Path, statuses: &[TaskStatus]) -> io::Result<Vec<Self>> {
         let mut tasks = Vec::new();
@@ -227,7 +297,7 @@ impl Task {
                 }
             }
         }
-        tasks.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        tasks.sort_by_key(|task| task.created_at);
         Ok(tasks)
     }
 
@@ -235,9 +305,14 @@ impl Task {
     pub fn update_status(&mut self, new_status: TaskStatus) -> io::Result<()> {
         let old_path = self.file_path();
         let new_path = Self::status_dir(&self.base_dir, new_status).join(format!("{}.md", self.id));
-        let updated_at = Utc::now();
+        let updated_at = Local::now().naive_local();
+        let completed_at = match (self.status, new_status) {
+            (TaskStatus::Doing, TaskStatus::Done) => Some(updated_at),
+            (TaskStatus::Done, TaskStatus::Doing) => None,
+            _ => self.completed_at,
+        };
         let existing = fs::read_to_string(&old_path)?;
-        let content = self.content_with_updated_frontmatter(&existing, updated_at)?;
+        let content = self.content_with_updated_frontmatter(&existing, updated_at, completed_at)?;
         fs::create_dir_all(new_path.parent().unwrap())?;
         Self::replace_file_content(&old_path, &content, "md.update")?;
         if let Err(move_error) = fs::rename(&old_path, &new_path) {
@@ -254,6 +329,7 @@ impl Task {
         }
         self.status = new_status;
         self.updated_at = updated_at;
+        self.completed_at = completed_at;
         Ok(())
     }
 
@@ -261,10 +337,12 @@ impl Task {
     fn content_with_updated_frontmatter(
         &self,
         existing: &str,
-        updated_at: DateTime<Utc>,
+        updated_at: NaiveDateTime,
+        completed_at: Option<NaiveDateTime>,
     ) -> io::Result<String> {
         let frontmatter = TaskFrontmatter {
             updated_at,
+            completed_at,
             ..self.frontmatter()
         };
         self.content_with_frontmatter(existing, frontmatter)
@@ -311,10 +389,10 @@ impl Task {
         let mut todos = Self::filter_by_status(&tasks, TaskStatus::Todo);
         let mut doings = Self::filter_by_status(&tasks, TaskStatus::Doing);
         let mut dones = Self::filter_by_status(&tasks, TaskStatus::Done);
-        parking.sort_by(|a, b| a.created_at.cmp(&b.created_at));
-        todos.sort_by(|a, b| a.created_at.cmp(&b.created_at));
-        doings.sort_by(|a, b| a.created_at.cmp(&b.created_at));
-        dones.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        parking.sort_by_key(|task| task.created_at);
+        todos.sort_by_key(|task| task.created_at);
+        doings.sort_by_key(|task| task.created_at);
+        dones.sort_by_key(|task| task.created_at);
         [parking, todos, doings, dones].concat()
     }
 
@@ -380,6 +458,43 @@ mod tests {
 
         // THEN
         assert_eq!(task.deadline, expected);
+    }
+
+    #[test]
+    fn new_task_uses_local_naive_datetime() {
+        // GIVEN
+        let before = Local::now().naive_local();
+
+        // WHEN
+        let task = Task::new("local datetime test".to_string());
+
+        // THEN
+        let after = Local::now().naive_local();
+        assert!(task.created_at >= before);
+        assert!(task.created_at <= after);
+        assert_eq!(task.updated_at, task.created_at);
+        assert_eq!(task.completed_at, None);
+    }
+
+    #[test]
+    fn week_start_returns_monday_across_calendar_boundaries() {
+        // GIVEN
+        let dates = [
+            NaiveDate::from_ymd_opt(2026, 6, 15).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 6, 21).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+        ];
+        let expected = [
+            NaiveDate::from_ymd_opt(2026, 6, 15).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 6, 15).unwrap(),
+            NaiveDate::from_ymd_opt(2025, 12, 29).unwrap(),
+        ];
+
+        // WHEN
+        let actual = dates.map(Task::week_start);
+
+        // THEN
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -532,6 +647,66 @@ mod tests {
     }
 
     #[test]
+    fn load_migrates_utc_timestamps_without_changing_clock_time() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let todo_dir = tasks_dir.join("todo");
+        fs::create_dir_all(&todo_dir).unwrap();
+        let id = Uuid::new_v4();
+        let path = todo_dir.join(format!("{id}.md"));
+        let content = format!(
+            "---\nid: {id}\nname: legacy utc\ncreated_at: 2026-06-15T10:00:00Z\nupdated_at: 2026-06-15T11:30:00+09:00\ndeadline: 2026/06/16\n---\n## Notes\n"
+        );
+        fs::write(&path, content).unwrap();
+        let expected_created_at = NaiveDate::from_ymd_opt(2026, 6, 15)
+            .unwrap()
+            .and_hms_opt(10, 0, 0)
+            .unwrap();
+        let expected_updated_at = NaiveDate::from_ymd_opt(2026, 6, 15)
+            .unwrap()
+            .and_hms_opt(11, 30, 0)
+            .unwrap();
+
+        // WHEN
+        let task = Task::load(&path, TaskStatus::Todo).unwrap();
+
+        // THEN
+        let migrated_content = fs::read_to_string(&path).unwrap();
+        assert_eq!(task.created_at, expected_created_at);
+        assert_eq!(task.updated_at, expected_updated_at);
+        assert!(!migrated_content.contains('Z'));
+        assert!(!migrated_content.contains("+09:00"));
+        assert!(migrated_content.ends_with("## Notes\n"));
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn load_done_uses_updated_at_for_missing_completed_at() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let todo_dir = tasks_dir.join("todo");
+        let done_dir = tasks_dir.join("done");
+        let task = Task::new_in("legacy done".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        fs::create_dir_all(&done_dir).unwrap();
+        let done_path = done_dir.join(format!("{}.md", task.id));
+        fs::rename(task.file_path(), &done_path).unwrap();
+        let expected = task.updated_at;
+
+        // WHEN
+        let loaded = Task::load(&done_path, TaskStatus::Done).unwrap();
+
+        // THEN
+        let migrated_content = fs::read_to_string(&done_path).unwrap();
+        assert_eq!(loaded.completed_at, Some(expected));
+        assert!(migrated_content.contains("completed_at:"));
+        assert!(!todo_dir.join(format!("{}.md", task.id)).exists());
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
     fn failed_deadline_migration_preserves_original_content() {
         // GIVEN
         let tasks_dir = temporary_tasks_dir();
@@ -627,6 +802,97 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(task.status, expected_status);
         assert_eq!(task.updated_at, expected_updated_at);
+    }
+
+    #[test]
+    fn moving_doing_task_to_done_sets_completed_at() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let mut task = Task::new_in("complete task".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        task.update_status(TaskStatus::Doing).unwrap();
+
+        // WHEN
+        task.update_status(TaskStatus::Done).unwrap();
+
+        // THEN
+        assert_eq!(task.completed_at, Some(task.updated_at));
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn reopening_done_task_clears_completed_at() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let mut task = Task::new_in("reopen task".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        task.update_status(TaskStatus::Doing).unwrap();
+        task.update_status(TaskStatus::Done).unwrap();
+
+        // WHEN
+        task.update_status(TaskStatus::Doing).unwrap();
+
+        // THEN
+        assert_eq!(task.completed_at, None);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn completing_reopened_task_sets_new_completed_at() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let mut task = Task::new_in("complete again".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        task.update_status(TaskStatus::Doing).unwrap();
+        task.update_status(TaskStatus::Done).unwrap();
+        let first_completed_at = task.completed_at;
+        task.update_status(TaskStatus::Doing).unwrap();
+
+        // WHEN
+        task.update_status(TaskStatus::Done).unwrap();
+
+        // THEN
+        assert!(task.completed_at.is_some());
+        assert!(task.completed_at >= first_completed_at);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn load_done_for_week_includes_monday_through_sunday() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let week_start = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+        let completed_dates = [
+            ("monday", NaiveDate::from_ymd_opt(2026, 6, 15).unwrap()),
+            ("sunday", NaiveDate::from_ymd_opt(2026, 6, 21).unwrap()),
+            ("next monday", NaiveDate::from_ymd_opt(2026, 6, 22).unwrap()),
+        ];
+        completed_dates
+            .into_iter()
+            .map(|(name, date)| {
+                let mut task = Task::new_in(name.to_string(), tasks_dir.clone());
+                task.status = TaskStatus::Done;
+                task.completed_at = date.and_hms_opt(12, 0, 0);
+                task
+            })
+            .try_for_each(|task| task.save())
+            .unwrap();
+        let expected = ["monday", "sunday"];
+
+        // WHEN
+        let tasks = Task::load_done_for_week_from(&tasks_dir, week_start).unwrap();
+
+        // THEN
+        let actual = tasks
+            .iter()
+            .map(|task| task.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -237,6 +237,8 @@ fn moving_task_to_hidden_done_selects_nearby_visible_task() {
 
     // THEN
     assert!(done_path.exists());
+    let done_content = fs::read_to_string(&done_path).unwrap();
+    assert!(done_content.contains("completed_at:"));
     assert!(
         app.tasks
             .iter()


### PR DESCRIPTION
## Summary
Add weekly DONE reviews based on Monday-to-Sunday completion periods. Pressing `d` opens the current week, while `[` and `]` navigate previous and subsequent weeks without moving beyond the current week. The DONE column displays its review period and each completed task shows its completion date-time.

Task metadata now stores `created_at`, `updated_at`, and optional `completed_at` as local `NaiveDateTime` values without timezone information. Existing RFC 3339 timestamps are migrated while preserving their clock values, and legacy DONE tasks derive `completed_at` from `updated_at`. Moving a task to DONE records completion, while reopening it clears the completion timestamp.

The change includes focused unit and integration coverage for timestamp migration, completion lifecycle, week boundaries, navigation, rendering, and DONE filtering. README and repository guidance are updated for the new workflow.

## Background
The application previously exposed all DONE tasks as a single unfiltered column and did not record when a task was completed. This made it difficult to review accomplishments as a one-week sprint.

This change introduces completion-based weekly review without adding sprint-planning metadata or changing the existing PARKING / TODO / DOING workflow. It keeps DONE loading lazy, supports reviewing past weeks directly in the existing TUI, and prevents newly completed tasks from appearing in a different week than their recorded completion date.