### PR TITLE
Add reload key `r`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A TUI (Terminal User Interface) TODO management tool. `rem` stands for "remember
 | `h` / `l` | Navigate left / right between statuses |
 | `n` | Move task to next status (PARKING -> TODO -> DOING -> DONE) |
 | `N` | Move task to previous status (DONE -> DOING -> TODO -> PARKING) |
+| `r` | Reload tasks from the filesystem |
 | `d` | Toggle this week's DONE tasks |
 | `[` / `]` | Show the previous / next DONE week |
 | `Enter` | Open task file in neovim |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use chrono::{Days, Local, NaiveDate};
+use chrono::{Days, Local, NaiveDate, NaiveDateTime};
 use crossterm::event::KeyCode;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -24,6 +24,7 @@ pub struct App {
     pub parking_loaded: bool,
     pub done_loaded: bool,
     pub done_week_start: NaiveDate,
+    pub last_updated_at: NaiveDateTime,
     pub open_file: Option<PathBuf>,
     pub error_message: Option<String>,
     pub(crate) tasks_dir: PathBuf,
@@ -48,7 +49,8 @@ impl App {
 
     /// Creates an `App` using the provided task storage directory.
     pub fn with_tasks_dir(tasks_dir: PathBuf) -> Self {
-        let done_week_start = Task::week_start(Local::now().date_naive());
+        let now = Local::now().naive_local();
+        let done_week_start = Task::week_start(now.date());
         let todo_result = Task::load_todo_from(&tasks_dir);
         let doing_result = Task::load_doing_from(&tasks_dir);
         let error_message = todo_result
@@ -70,6 +72,7 @@ impl App {
             parking_loaded: false,
             done_loaded: false,
             done_week_start,
+            last_updated_at: now,
             open_file: None,
             error_message: error_message.clone(),
             tasks_dir,
@@ -137,6 +140,7 @@ impl App {
                     KeyCode::Char('G') => self.select_last(),
                     KeyCode::Char('n') => self.forward_status(),
                     KeyCode::Char('N') => self.backward_status(),
+                    KeyCode::Char('r') => self.reload_tasks(),
                     KeyCode::Char('d') => self.toggle_done(),
                     KeyCode::Char('[') => self.show_previous_done_week(),
                     KeyCode::Char(']') => self.show_next_done_week(),
@@ -320,6 +324,63 @@ impl App {
     /// Handles post-edit cleanup after returning from neovim.
     pub fn after_edit(&mut self) {
         self.reload_selected_task();
+    }
+
+    fn reload_tasks(&mut self) {
+        let selection = self.selected_index.and_then(|index| {
+            let selected = self.tasks.get(index)?;
+            let row = self
+                .indices_for_status(selected.status)
+                .iter()
+                .position(|candidate| *candidate == index)
+                .unwrap_or(0);
+            Some((selected.id, selected.status, row))
+        });
+        let mut loaded_tasks =
+            match Self::load_visible_tasks(&self.tasks_dir, self.done_loaded, self.done_week_start)
+            {
+                Ok(tasks) => tasks,
+                Err(error) => {
+                    self.error_message = Some(
+                        self.error_with_persistent(format!("Failed to reload tasks: {error}")),
+                    );
+                    return;
+                }
+            };
+        loaded_tasks = Task::sort(loaded_tasks);
+        self.tasks = loaded_tasks;
+        self.parking_loaded = true;
+        self.last_updated_at = Local::now().naive_local();
+        self.error_message = self.persistent_error.clone();
+        self.selected_index = selection
+            .and_then(|(id, status, row)| {
+                self.tasks
+                    .iter()
+                    .position(|task| task.id == id)
+                    .or_else(|| self.nearby_selection(status, row))
+            })
+            .or_else(|| (!self.tasks.is_empty()).then_some(0));
+    }
+
+    fn load_visible_tasks(
+        tasks_dir: &std::path::Path,
+        done_loaded: bool,
+        done_week_start: NaiveDate,
+    ) -> std::io::Result<Vec<Task>> {
+        let parking_tasks = Task::load_parking_from(tasks_dir)?;
+        let todo_tasks = Task::load_todo_from(tasks_dir)?;
+        let doing_tasks = Task::load_doing_from(tasks_dir)?;
+        let done_tasks = if done_loaded {
+            Task::load_done_for_week_from(tasks_dir, done_week_start)?
+        } else {
+            Vec::new()
+        };
+        Ok(parking_tasks
+            .into_iter()
+            .chain(todo_tasks)
+            .chain(doing_tasks)
+            .chain(done_tasks)
+            .collect())
     }
 
     /// Advances the selected task's status: PARKING -> TODO -> DOING -> DONE.
@@ -571,6 +632,7 @@ mod tests {
             parking_loaded: true,
             done_loaded: false,
             done_week_start: Task::week_start(Local::now().date_naive()),
+            last_updated_at: Local::now().naive_local(),
             open_file: None,
             error_message: None,
             tasks_dir: Task::default_base_dir(),
@@ -659,6 +721,153 @@ mod tests {
         // THEN
         assert!(app.parking_loaded);
         assert_eq!(app.error_message, expected);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn reload_key_loads_parking_todo_and_doing_tasks() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let tasks = [
+            ("reloaded parking", TaskStatus::Parking),
+            ("reloaded todo", TaskStatus::Todo),
+            ("reloaded doing", TaskStatus::Doing),
+        ];
+        tasks
+            .into_iter()
+            .map(|(name, status)| {
+                let mut task = Task::new_in(name.to_string(), tasks_dir.clone());
+                task.status = status;
+                task
+            })
+            .try_for_each(|task| task.save())
+            .unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('r'));
+
+        // THEN
+        let actual = app
+            .tasks
+            .iter()
+            .map(|task| task.name.as_str())
+            .collect::<Vec<_>>();
+        let expected = ["reloaded parking", "reloaded todo", "reloaded doing"];
+        assert_eq!(actual, expected);
+        assert!(app.parking_loaded);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn reload_key_keeps_done_hidden_when_done_is_not_loaded() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let mut task = Task::new_in("hidden done".to_string(), tasks_dir.clone());
+        task.status = TaskStatus::Done;
+        task.completed_at = Some(Local::now().naive_local());
+        task.save().unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('r'));
+
+        // THEN
+        assert!(!app.done_loaded);
+        assert!(app.tasks.iter().all(|task| task.status != TaskStatus::Done));
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn reload_key_refreshes_visible_done_week() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        app.handle_key_event(KeyCode::Char('d'));
+        let mut task = Task::new_in("visible done".to_string(), tasks_dir.clone());
+        task.status = TaskStatus::Done;
+        task.completed_at = Some(app.done_week_start.and_hms_opt(12, 0, 0).unwrap());
+        task.save().unwrap();
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('r'));
+
+        // THEN
+        let actual = app
+            .tasks
+            .iter()
+            .find(|task| task.status == TaskStatus::Done)
+            .map(|task| task.name.as_str());
+        let expected = Some("visible done");
+        assert_eq!(actual, expected);
+        assert!(app.done_loaded);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn reload_key_updates_last_updated_at_after_success() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        fs::create_dir_all(&tasks_dir).unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        let expected_before = NaiveDate::from_ymd_opt(2026, 6, 15)
+            .unwrap()
+            .and_hms_opt(10, 30, 45)
+            .unwrap();
+        app.last_updated_at = expected_before;
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('r'));
+
+        // THEN
+        assert!(app.last_updated_at > expected_before);
+
+        fs::remove_dir_all(tasks_dir).unwrap();
+    }
+
+    #[test]
+    fn reload_key_keeps_existing_state_when_load_fails() {
+        // GIVEN
+        let tasks_dir = temporary_tasks_dir();
+        let task = Task::new_in("existing todo".to_string(), tasks_dir.clone());
+        task.save().unwrap();
+        let mut app = App::with_tasks_dir(tasks_dir.clone());
+        let expected_tasks = app
+            .tasks
+            .iter()
+            .map(|task| (task.name.clone(), task.status))
+            .collect::<Vec<_>>();
+        let expected_selected_index = app.selected_index;
+        let expected_last_updated_at = NaiveDate::from_ymd_opt(2026, 6, 15)
+            .unwrap()
+            .and_hms_opt(10, 30, 45)
+            .unwrap();
+        app.last_updated_at = expected_last_updated_at;
+        fs::remove_dir_all(tasks_dir.join("todo")).unwrap();
+        fs::write(tasks_dir.join("todo"), "not a directory").unwrap();
+
+        // WHEN
+        app.handle_key_event(KeyCode::Char('r'));
+
+        // THEN
+        let actual_tasks = app
+            .tasks
+            .iter()
+            .map(|task| (task.name.clone(), task.status))
+            .collect::<Vec<_>>();
+        assert_eq!(actual_tasks, expected_tasks);
+        assert_eq!(app.selected_index, expected_selected_index);
+        assert_eq!(app.last_updated_at, expected_last_updated_at);
+        assert!(
+            app.error_message
+                .as_deref()
+                .unwrap()
+                .contains("Failed to reload tasks")
+        );
 
         fs::remove_dir_all(tasks_dir).unwrap();
     }
@@ -1015,6 +1224,7 @@ mod tests {
             parking_loaded: true,
             done_loaded: false,
             done_week_start: Task::week_start(Local::now().date_naive()),
+            last_updated_at: Local::now().naive_local(),
             open_file: None,
             error_message: None,
             tasks_dir,

--- a/src/render.rs
+++ b/src/render.rs
@@ -95,6 +95,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(frame.area())
     };
 
+    let main = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(outer[0]);
     let statuses = if app.done_loaded {
         let done_week_end = app
             .done_week_start
@@ -121,8 +122,14 @@ pub fn render(frame: &mut Frame, app: &App) {
         ]
     };
     let constraints = vec![Constraint::Ratio(1, statuses.len() as u32); statuses.len()];
-    let columns = Layout::horizontal(constraints).split(outer[0]);
+    let columns = Layout::horizontal(constraints).split(main[1]);
     let today = Local::now().date_naive();
+    let last_updated = Paragraph::new(format!(
+        " last updated: {}",
+        app.last_updated_at.format(TASK_DATETIME_FORMAT)
+    ))
+    .alignment(Alignment::Right);
+    frame.render_widget(last_updated, main[0]);
 
     for (column, ((status, title), area)) in statuses.iter().zip(columns.iter()).enumerate() {
         let mut selected_in_group: Option<usize> = None;
@@ -200,7 +207,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         let (message, style) = app.error_message.as_deref().map_or_else(
             || {
                 (
-                    " a: add | j/k: up/down | G/gg: bottom/top | h/l: left/right | n/N: status | d: done | [/]: done week | q: quit ",
+                    " a: add | j/k: up/down | G/gg: bottom/top | h/l: left/right | n/N: status | r: reload | d: done | [/]: done week | q: quit ",
                     Style::default(),
                 )
             },
@@ -228,6 +235,10 @@ mod tests {
             parking_loaded: false,
             done_loaded,
             done_week_start: Task::week_start(Local::now().date_naive()),
+            last_updated_at: NaiveDate::from_ymd_opt(2026, 6, 15)
+                .unwrap()
+                .and_hms_opt(10, 30, 45)
+                .unwrap(),
             open_file: None,
             error_message: None,
             tasks_dir: Task::default_base_dir(),
@@ -320,7 +331,7 @@ mod tests {
         // THEN
         let buffer = terminal.backend().buffer();
         let done_border = buffer
-            .cell((buffer.area.width - 1, 1))
+            .cell((buffer.area.width - 1, 2))
             .expect("DONE border should exist");
         assert_eq!(done_border.fg, Color::Green);
     }
@@ -329,6 +340,18 @@ mod tests {
     fn renders_navigation_help() {
         // GIVEN
         let expected = "G/gg: bottom/top";
+
+        // WHEN
+        let actual = rendered_text(false);
+
+        // THEN
+        assert!(actual.contains(expected));
+    }
+
+    #[test]
+    fn renders_last_updated_at_right_top() {
+        // GIVEN
+        let expected = "last updated: 2026/06/15 10:30:45";
 
         // WHEN
         let actual = rendered_text(false);


### PR DESCRIPTION
## Summary
Adds a Normal mode `r` keybinding that reloads the visible task list from the filesystem. The reload refreshes PARKING, TODO, and DOING tasks every time, preserves the existing DONE visibility behavior, and refreshes the current DONE week only when DONE is already visible.

This PR also displays `last updated: yyyy/MM/dd HH:mm:ss` at the top right of the TUI so users can see when the in-memory task list was last successfully loaded. The keybinding help and README are updated to document the new reload command.

## Background
rem-cli stores tasks as local markdown files, so task files can be changed outside the running TUI by editors, scripts, or synced clients. Before this change, users had to restart the application to refresh the window after external filesystem updates. The new reload key makes those external changes visible without leaving the TUI while keeping the existing DONE lazy-loading and weekly review behavior.